### PR TITLE
Update: Improve cache time

### DIFF
--- a/app.py
+++ b/app.py
@@ -116,7 +116,7 @@ def fetch_all_r18_results(hallticket):
         results["overall_gpa"] = round(total_gpa, 2)
 
     redis_client.set(current_key, json.dumps({"data": results}))
-    redis_client.expire(current_key, timedelta(hours=1))
+    redis_client.expire(current_key, timedelta(hours=24))
     return Response(json.dumps({"data": results}), mimetype="application/json")
 
 


### PR DESCRIPTION
Increase the cache time of `all-r18` results to 24 hours.